### PR TITLE
test(frontend): add robust home page tabs and a11y checks (#37)

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -2,7 +2,7 @@ use chrono::Local;
 use fern::Dispatch;
 use log::LevelFilter;
 use serde::Serialize;
-use tauri::{App, Manager, Wry, Emitter};
+use tauri::{App, Emitter, Manager, Wry};
 
 #[derive(Clone, Serialize)]
 struct LogPayload {
@@ -32,7 +32,8 @@ pub fn setup_logging(app: &mut App<Wry>) -> Result<(), fern::InitError> {
                 message: message.to_string(),
                 timestamp,
             };
-            app_handle.emit("log-message", log_payload)
+            app_handle
+                .emit("log-message", log_payload)
                 .expect("failed to emit log event");
         })
         .level(LevelFilter::Info)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-  app_lib::run().expect("Failed to run Tauri application");
+    app_lib::run().expect("Failed to run Tauri application");
 }

--- a/src-tauri/tests/json_integration.rs
+++ b/src-tauri/tests/json_integration.rs
@@ -50,7 +50,11 @@ fn triage_cli_json_is_pure_and_parses() {
         .output()
         .expect("run cli triage json");
 
-    assert!(out.status.success(), "triage failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "triage failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 
     let stdout = String::from_utf8_lossy(&out.stdout);
 


### PR DESCRIPTION
This PR rewrites page.spec.ts to provide robust UI assertions (tabs, view toggling) and adds a jest-axe a11y check on +page.svelte.

- Handles initial loading state by awaiting queue refresh
- Verifies Lab and Settings UIs and controls
- Adds a11y baseline via jest-axe

Linked: #37